### PR TITLE
Extend demo to use HM ensembles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,6 @@ install:
   - sed -i "s&\./webviz-subsurface-testdata/&\.\./&g" tests/integration_tests/test_raw_data_example.py
   - sed -i "s&\./webviz-subsurface-testdata/&\.\./&g" tests/integration_tests/test_aggregated_data_example.py
   - popd
-  # Need to find full path to testdata due to https://github.com/equinor/webviz-subsurface/issues/128
-  - sed -i "s&\.\./&$PWD/&g" webviz_examples/full_demo.yaml
-  - sed -i "s&\.\./&$PWD/&g" webviz_examples/raw_data.yaml
-  - sed -i "s&\.\./&$PWD/&g" webviz_examples/aggregated.yaml
 
 script:
   - yamllint .

--- a/webviz_examples/full_demo.yaml
+++ b/webviz_examples/full_demo.yaml
@@ -33,6 +33,7 @@ pages:
 
   - title: Reservoir simulation map
     content:
+      - In this example, the horizontal permeability is shown together with oil fluid flow for a given date during simulation.
       - container: SubsurfaceMap
         ensemble: iter-0
         map_value: PERMX

--- a/webviz_examples/full_demo.yaml
+++ b/webviz_examples/full_demo.yaml
@@ -44,7 +44,10 @@ pages:
     content:
       - container: InplaceVolumes
         ensembles:
-          - sens_run
+          - iter-0
+          - iter-1
+          - iter-2
+          - iter-3
         volfiles:
           geogrid: geogrid--oil.csv
           simgrid: simgrid--oil.csv

--- a/webviz_examples/full_demo.yaml
+++ b/webviz_examples/full_demo.yaml
@@ -70,7 +70,7 @@ pages:
         ensembles:
           - iter-0
           - iter-1
-          - iter-2          
+          - iter-2
           - iter-3
 
   - title: Parameter correlation

--- a/webviz_examples/full_demo.yaml
+++ b/webviz_examples/full_demo.yaml
@@ -1,8 +1,12 @@
 title: Reek Webviz Example
 
-container_settings:
+shared_settings:
   scratch_ensembles:
-    iter-0: ../reek_fullmatrix/realization-*/iter-0
+    sens_run: ../reek_fullmatrix/realization-*/iter-0
+    iter-0: ../reek_history_match/realization-*/iter-0
+    iter-1: ../reek_history_match/realization-*/iter-1
+    iter-2: ../reek_history_match/realization-*/iter-2
+    iter-3: ../reek_history_match/realization-*/iter-3
 
 pages:
 
@@ -19,18 +23,27 @@ pages:
       - container: ReservoirSimulationTimeSeries
         ensembles:
           - iter-0
+          - iter-1
+          - iter-2
+          - iter-3
+        obsfile: ../reek_history_match/share/observations/observations.yml
         options:
-          vector1: FOPT
-          vector2: FGPT
-          vector3: FWPT
-          date: 2003-02-01
-          visualization: statistics_hist
+          vector1: WOPR:OP_1
+          visualization: statistics
+
+  - title: Reservoir simulation map
+    content:
+      - container: SubsurfaceMap
+        ensemble: iter-0
+        map_value: PERMX
+        flow_value: FLROIL
+        time_step: 2
 
   - title: Inplace volumes
     content:
       - container: InplaceVolumes
         ensembles:
-          - iter-0
+          - sens_run
         volfiles:
           geogrid: geogrid--oil.csv
           simgrid: simgrid--oil.csv
@@ -39,7 +52,7 @@ pages:
     content:
       - container: InplaceVolumesOneByOne
         ensembles:
-          - iter-0
+          - sens_run
         volfiles:
           geogrid: geogrid--oil.csv
           simgrid: simgrid--oil.csv
@@ -48,7 +61,7 @@ pages:
     content:
       - container: ReservoirSimulationTimeSeriesOneByOne
         ensembles:
-          - iter-0
+          - sens_run
         initial_vector: FOPT
 
   - title: Parameter distribution
@@ -56,12 +69,28 @@ pages:
       - container: ParameterDistribution
         ensembles:
           - iter-0
+          - iter-1
+          - iter-2          
+          - iter-3
 
   - title: Parameter correlation
     content:
       - container: ParameterCorrelation
         ensembles:
           - iter-0
+          - iter-1
+          - iter-2
+          - iter-3
+
+  - title: History match
+    content:
+      - container: HistoryMatch
+        observation_file: ../reek_history_match/share/observations/observations.yml
+        ensembles:
+          - iter-0
+          - iter-1
+          - iter-2
+          - iter-3
 
   - title: SEG-Y viewer
     content:

--- a/webviz_examples/full_demo.yaml
+++ b/webviz_examples/full_demo.yaml
@@ -18,6 +18,34 @@ pages:
       - container: Markdown
         markdown_file: ./content/front_page.md
 
+  - title: Sensitivity study (inplace)
+    content:
+      - container: InplaceVolumesOneByOne
+        ensembles:
+          - sens_run
+        volfiles:
+          geogrid: geogrid--oil.csv
+          simgrid: simgrid--oil.csv
+
+  - title: Sensitivity study (time series)
+    content:
+      - container: ReservoirSimulationTimeSeriesOneByOne
+        ensembles:
+          - sens_run
+        initial_vector: FOPT
+
+  - title: Inplace volumes
+    content:
+      - container: InplaceVolumes
+        ensembles:
+          - iter-0
+          - iter-1
+          - iter-2
+          - iter-3
+        volfiles:
+          geogrid: geogrid--oil.csv
+          simgrid: simgrid--oil.csv
+
   - title: Simulation time series
     content:
       - container: ReservoirSimulationTimeSeries
@@ -39,34 +67,6 @@ pages:
         map_value: PERMX
         flow_value: FLROIL
         time_step: 2
-
-  - title: Inplace volumes
-    content:
-      - container: InplaceVolumes
-        ensembles:
-          - iter-0
-          - iter-1
-          - iter-2
-          - iter-3
-        volfiles:
-          geogrid: geogrid--oil.csv
-          simgrid: simgrid--oil.csv
-
-  - title: Sensitivity study (inplace)
-    content:
-      - container: InplaceVolumesOneByOne
-        ensembles:
-          - sens_run
-        volfiles:
-          geogrid: geogrid--oil.csv
-          simgrid: simgrid--oil.csv
-
-  - title: Sensitivity study (time series)
-    content:
-      - container: ReservoirSimulationTimeSeriesOneByOne
-        ensembles:
-          - sens_run
-        initial_vector: FOPT
 
   - title: Parameter distribution
     content:

--- a/webviz_examples/raw_data.yaml
+++ b/webviz_examples/raw_data.yaml
@@ -1,8 +1,12 @@
 title: Reek Webviz Demonstration
 
-container_settings:
+shared_settings:
   scratch_ensembles:
-    iter-0: ../reek_fullmatrix/realization-*/iter-0
+    sens_run: ../reek_fullmatrix/realization-*/iter-0
+    iter-0: ../reek_history_match/realization-*/iter-0
+    iter-1: ../reek_history_match/realization-*/iter-1
+    iter-2: ../reek_history_match/realization-*/iter-2
+    iter-3: ../reek_history_match/realization-*/iter-3
 
 pages:
 
@@ -14,22 +18,30 @@ pages:
     content:
       - container: InplaceVolumesOneByOne
         ensembles:
-          - iter-0
+          - sens_run
         volfiles:
           geogrid: geogrid--oil.csv
           simgrid: simgrid--oil.csv
+
+  - title: Reservoir simulation map
+    content:
+      - container: SubsurfaceMap
+        ensemble: iter-0
+        map_value: PERMX
+        flow_value: FLROIL
+        time_step: 2
 
   - title: ReservoirSimulationTimeSeriesOneByOne
     content:
       - container: ReservoirSimulationTimeSeriesOneByOne
         ensembles:
-          - iter-0
+          - sens_run
 
   - title: InplaceVolumes
     content:
       - container: InplaceVolumes
         ensembles:
-          - iter-0
+          - sens_run
         volfiles:
           geogrid: geogrid--oil.csv
           simgrid: simgrid--oil.csv
@@ -39,24 +51,46 @@ pages:
       - container: ParameterDistribution
         ensembles:
           - iter-0
+          - iter-1
+          - iter-2
+          - iter-3
 
   - title: ParameterCorrelation
     content:
       - container: ParameterCorrelation
         ensembles:
           - iter-0
+          - iter-1
+          - iter-2
+          - iter-3
+
+  - title: History match
+    content:
+      - container: HistoryMatch
+        observation_file: ../reek_history_match/share/observations/observations.yml
+        ensembles:
+          - iter-0
+          - iter-1
+          - iter-2
+          - iter-3
 
   - title: ReservoirSimulationTimeSeries
     content:
       - container: ReservoirSimulationTimeSeries
         ensembles:
           - iter-0
+          - iter-1
+          - iter-2
+          - iter-3
 
   - title: ReservoirSimulationTimeSeries (with options set)
     content:
       - container: ReservoirSimulationTimeSeries
         ensembles:
           - iter-0
+          - iter-1
+          - iter-2
+          - iter-3
         options:
           vector1: FOPT
           vector2: FGPT


### PR DESCRIPTION
Extend the webviz demonstration configuration files to also use the newly added history match ensembles.