### PR TITLE
Disk usage added to testdata

### DIFF
--- a/.disk_usage/disk_usage_user_2020-07-11.csv
+++ b/.disk_usage/disk_usage_user_2020-07-11.csv
@@ -1,0 +1,3 @@
+userid,usageKB
+kari,123456
+ola,34512

--- a/webviz_examples/full_demo.yaml
+++ b/webviz_examples/full_demo.yaml
@@ -26,6 +26,12 @@ pages:
           filename: ./full_demo.yaml
           dark_theme: yes
 
+  - title: Disk usage
+    content:
+      - DiskUsage:
+          scratch_dir: ../.
+          date: 2020-07-11 # Date only necessary if you want an explicit date.
+
   - title: Sensitivity study (inplace)
     content:
       - InplaceVolumesOneByOne:


### PR DESCRIPTION
Data for https://github.com/equinor/webviz-subsurface/pull/385.
CI failing until merger of https://github.com/equinor/webviz-subsurface/pull/385, as date input does not exist in current `DiskUsage`. 
Suggest to merge this one as failing, and get 🟢  in webviz-subsurface.