### PR TITLE
included ParameterResponseCorrelation with RFTs as responses

### DIFF
--- a/webviz_examples/webviz-full-demo.yml
+++ b/webviz_examples/webviz-full-demo.yml
@@ -282,10 +282,10 @@ layout:
                     zone: multi
                     time: multi
                   response_include:
-                  - pressure
-                  - swat
-                  - sgas
-                  - soil
+                    - pressure
+                    - swat
+                    - sgas
+                    - soil
                   aggregation: mean
 
           - page: Pairwise correlation between input parameters


### PR DESCRIPTION
This is a good usecase for the ParameterResponseCorrelation plugin. Matching RFT pressures is often the first priority in history matching and it's important to see the RFT pressure's sensitivity to the input parameters.