### PR TITLE
Remove clumnn_keys argument from ParameterAnalysis

### DIFF
--- a/webviz_examples/webviz-full-demo.yml
+++ b/webviz_examples/webviz-full-demo.yml
@@ -393,7 +393,6 @@ layout:
               - ParameterAnalysis:
                   ensembles: *hm_ensembles
                   time_index: "monthly"
-                  column_keys: ["WWCT:*"]
                   drop_constants: true
 
           - page: Line plotter (FMU)


### PR DESCRIPTION
The introduction of `arrow` file support and vectorselector in ParameterAnalysis https://github.com/equinor/webviz-subsurface/pull/988 makes it easy to use all vectors inside the plugin